### PR TITLE
[Merge] #97 Firebase Push Notification 보내는 로직 + FCM token 저장

### DIFF
--- a/TeamOXY/TeamOXY.xcodeproj/project.pbxproj
+++ b/TeamOXY/TeamOXY.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		F2CA7CE42858092F0094B126 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F2CA7CE32858092F0094B126 /* GoogleService-Info.plist */; };
 		F2CA7CFB2858154A0094B126 /* MeetingRoomViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2CA7CFA2858154A0094B126 /* MeetingRoomViewModel.swift */; };
 		F2CA7CFD285825EE0094B126 /* MeetingRoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2CA7CFC285825EE0094B126 /* MeetingRoom.swift */; };
-		F2D58A322859F25600ACFF51 /* CarouselViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D58A312859F25600ACFF51 /* CarouselViewModel.swift */; };
+		F2D58A36285A002800ACFF51 /* SendNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D58A35285A002800ACFF51 /* SendNotification.swift */; };
 		F2D707B82849BA6C00DA86FD /* TeamOXYApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D707B72849BA6C00DA86FD /* TeamOXYApp.swift */; };
 		F2D707BC2849BA6D00DA86FD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F2D707BB2849BA6D00DA86FD /* Assets.xcassets */; };
 		F2D707BF2849BA6D00DA86FD /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F2D707BE2849BA6D00DA86FD /* Preview Assets.xcassets */; };
@@ -121,7 +121,9 @@
 		F2CA7CE32858092F0094B126 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		F2CA7CFA2858154A0094B126 /* MeetingRoomViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingRoomViewModel.swift; sourceTree = "<group>"; };
 		F2CA7CFC285825EE0094B126 /* MeetingRoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingRoom.swift; sourceTree = "<group>"; };
-		F2D58A312859F25600ACFF51 /* CarouselViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselViewModel.swift; sourceTree = "<group>"; };
+		F2D58A35285A002800ACFF51 /* SendNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendNotification.swift; sourceTree = "<group>"; };
+		F2D58A38285A015600ACFF51 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		F2D58A39285A016C00ACFF51 /* Production.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Production.xcconfig; sourceTree = "<group>"; };
 		F2D707B42849BA6C00DA86FD /* TeamOXY.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TeamOXY.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F2D707B72849BA6C00DA86FD /* TeamOXYApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamOXYApp.swift; sourceTree = "<group>"; };
 		F2D707BB2849BA6D00DA86FD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -174,6 +176,7 @@
 				F2380A8A2856D500004754EE /* FirebaseManager.swift */,
 				F2380A8E2856D633004754EE /* generateRandomNickname.swift */,
 				21830A0A2858642300B279B6 /* HapticManager.swift */,
+				F2D58A35285A002800ACFF51 /* SendNotification.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -269,7 +272,6 @@
 				4A3B249A2855FFC000504486 /* CompletionViewModel.swift */,
 				F2380A922856EA65004754EE /* EmojiViewModel.swift */,
 				F2CA7CFA2858154A0094B126 /* MeetingRoomViewModel.swift */,
-				F2D58A312859F25600ACFF51 /* CarouselViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -307,6 +309,15 @@
 			path = QRCode;
 			sourceTree = "<group>";
 		};
+		F2D58A37285A013500ACFF51 /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				F2D58A38285A015600ACFF51 /* Debug.xcconfig */,
+				F2D58A39285A016C00ACFF51 /* Production.xcconfig */,
+			);
+			path = Config;
+			sourceTree = "<group>";
+		};
 		F2D707AB2849BA6C00DA86FD = {
 			isa = PBXGroup;
 			children = (
@@ -326,6 +337,7 @@
 		F2D707B62849BA6C00DA86FD /* TeamOXY */ = {
 			isa = PBXGroup;
 			children = (
+				F2D58A37285A013500ACFF51 /* Config */,
 				F2CA7CE32858092F0094B126 /* GoogleService-Info.plist */,
 				F225A1ED2856D4BC00166ECC /* Utils */,
 				F29BED1B28532DB8005B4A1B /* Components */,
@@ -460,7 +472,6 @@
 				F2CA7CFB2858154A0094B126 /* MeetingRoomViewModel.swift in Sources */,
 				4A3B249B2855FFC000504486 /* CompletionViewModel.swift in Sources */,
 				F29BED232853B24C005B4A1B /* CreateMeetingRoomView.swift in Sources */,
-				F2D58A322859F25600ACFF51 /* CarouselViewModel.swift in Sources */,
 				F2380A8B2856D500004754EE /* FirebaseManager.swift in Sources */,
 				21830A0B2858642300B279B6 /* HapticManager.swift in Sources */,
 				3F4E60092853A30300BFAA65 /* EmojiReactionView.swift in Sources */,
@@ -482,6 +493,7 @@
 				F29BED28285436F2005B4A1B /* QRCodeView.swift in Sources */,
 				4A2A97AA2856C7A400EA21C6 /* UIScreenExtension.swift in Sources */,
 				F29BED1F28533CBC005B4A1B /* String+ButtonImageName.swift in Sources */,
+				F2D58A36285A002800ACFF51 /* SendNotification.swift in Sources */,
 				7BC5EFB22851ECC5004A27B5 /* ColorExtension.swift in Sources */,
 				F2380A8D2856D567004754EE /* FirebaseConstants.swift in Sources */,
 				7BFBD2E32856C33B00E5D98C /* OnboardingLastPageView.swift in Sources */,
@@ -611,13 +623,14 @@
 		};
 		F2D707C32849BA6D00DA86FD /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F2D58A38285A015600ACFF51 /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"TeamOXY/Preview Content\"";
-				DEVELOPMENT_TEAM = AJK25G55CT;
+				DEVELOPMENT_TEAM = G3PA8G576S;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TeamOXY/Info.plist;
@@ -643,13 +656,14 @@
 		};
 		F2D707C42849BA6D00DA86FD /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F2D58A39285A016C00ACFF51 /* Production.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"TeamOXY/Preview Content\"";
-				DEVELOPMENT_TEAM = AJK25G55CT;
+				DEVELOPMENT_TEAM = G3PA8G576S;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TeamOXY/Info.plist;

--- a/TeamOXY/TeamOXY/Config/Debug.xcconfig
+++ b/TeamOXY/TeamOXY/Config/Debug.xcconfig
@@ -1,0 +1,11 @@
+//
+//  Debug.xcconfig
+//  TeamOXY
+//
+//  Created by 정재윤 on 2022/06/15.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+FIREBASE_SERVER_KEY = "AAAAlEEUTMc:APA91bGYLakvhEPcAqLP6T84mUbR0R6ssCD7AX5tFKaEKdvoeELvwB1_rZFhboYxWyHSOZiktZ20yMD1vlNMkaGf25uMaVOr0iqrFUNzebnaUNkWsaQo9Qg92jKDu5wn6jqbMuLvdZlm"

--- a/TeamOXY/TeamOXY/Config/Production.xcconfig
+++ b/TeamOXY/TeamOXY/Config/Production.xcconfig
@@ -1,0 +1,11 @@
+//
+//  Production.xcconfig
+//  TeamOXY
+//
+//  Created by 정재윤 on 2022/06/15.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+FIREBASE_SERVER_KEY = "AAAAlEEUTMc:APA91bGYLakvhEPcAqLP6T84mUbR0R6ssCD7AX5tFKaEKdvoeELvwB1_rZFhboYxWyHSOZiktZ20yMD1vlNMkaGf25uMaVOr0iqrFUNzebnaUNkWsaQo9Qg92jKDu5wn6jqbMuLvdZlm"

--- a/TeamOXY/TeamOXY/Constants/FirebaseConstants.swift
+++ b/TeamOXY/TeamOXY/Constants/FirebaseConstants.swift
@@ -17,4 +17,5 @@ struct FirebaseConstants {
     static let users = "users"
     static let reactions = "reactions"
     static let topics = "topics"
+    static let fcmToken = "fcmToken"
 }

--- a/TeamOXY/TeamOXY/Info.plist
+++ b/TeamOXY/TeamOXY/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>FIREBASE_SERVER_KEY</key>
+	<string>$(FIREBASE_SERVER_KEY)</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Black.otf</string>

--- a/TeamOXY/TeamOXY/Model/Topic.swift
+++ b/TeamOXY/TeamOXY/Model/Topic.swift
@@ -13,8 +13,8 @@ struct Topic: Codable, Identifiable {
 //    var id: String { documentId }
     @DocumentID var id: String?
 //    let documentId: String
-    let fromId, toId, topicTitle: String
-    let timestamp: Date
+    let topic: String
+    let isOnCardZone, isOnCardDeck, havingTheDiscussion: Bool
     
 //    init(documentId: String, data: [String: Any]) {
 //        self.documentId = documentId

--- a/TeamOXY/TeamOXY/Model/User.swift
+++ b/TeamOXY/TeamOXY/Model/User.swift
@@ -15,6 +15,7 @@ struct User: Codable, Identifiable {
     
     let uid: String
     let nickname: String?
+    let fcmtoken: String?
 
 //    init(data: [String : Any]) {
 //        self.uid = data["uid"] as? String ?? ""

--- a/TeamOXY/TeamOXY/Utils/SendNotification.swift
+++ b/TeamOXY/TeamOXY/Utils/SendNotification.swift
@@ -1,0 +1,66 @@
+//
+//  SendNotification.swift
+//  TeamOXY
+//
+//  Created by 정재윤 on 2022/06/15.
+//
+
+import SwiftUI
+import FirebaseMessaging
+import FirebaseFirestore
+import FirebaseFirestoreSwift
+
+class PushNotification: ObservableObject {
+    var serverKey: String { (Bundle.main.infoDictionary?["FIREBASE_SERVER_KEY"] as? String) ?? "" }
+    
+    func sendMessageToDevice(token: String, data: [String: String]) {
+        // Simple Logic
+        // Usinbg Firebase API to send Push Notification to another device using token
+        // Without haivng server...
+        
+        // Converting That to URL Request Format...
+        guard let url = URL(string: "https://fcm.googleapis.com/fcm/send") else {
+            print("Failed to ")
+            return
+        }
+        
+        let json: [String: Any] = [
+            "to": token,
+            "notification": [
+                "title": data["title"],
+                "body": data["body"]
+            ],
+            "data": [
+                // Data to be Sent...
+                // Dont pass empty or remove the block..
+                "user_name": data["uid"]
+            ]
+        ]
+        
+        //URL Reequest...
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        // Converting json Dict to JSON
+        request.httpBody = try? JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted])
+        // Setting Content Type and Authorization
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        // Authorization key will be Your Server Key....
+        request.setValue("key=\(self.serverKey)", forHTTPHeaderField: "Authorization")
+        
+        // Passing request using URL session.
+        let session = URLSession(configuration: .default)
+        
+        session.dataTask(with: request) { _, _, err in
+            if let err = err {
+                print("Failed to send message: \(err)")
+                return
+            }
+            
+            // Else Success
+            // Clearing Fields..
+            // Or Your Action when message sends...
+            print("Successfully send message")
+        }
+        .resume()  // task가 유예되었을 때 계속 진행하라는 메소드
+    }
+}


### PR DESCRIPTION
## 작업 내용
**Firebase Push Notification 보내는 로직**
- `PushNotification` class 생성
  - `serverKey` 환경 변수로 저장
    - Debug
    - Production
 - `sendMessageToDevice()` : 기기로 메시지 전송하는 메소드

**FCM token을 User 모델에 넣어서 Firestore에 저장**
- `MeetingRoomViewModel.storeuserInformation()` 안에 _FCM token_ 을 불러오는 로직 구현
- _FCM token_을 불러와서 userData에 넣어 `Firestore`에 저장

## 리뷰 포인트
- sendMessageToDevice()
- _FCM token_을 불러와서 `Firestore`에 저장

## 다음으로 진행될 작업

## 질문

## References
