### PR TITLE
[Merge] #99 reaction emoji animation 로직 변경

### DIFF
--- a/TeamOXY/TeamOXY.xcodeproj/project.pbxproj
+++ b/TeamOXY/TeamOXY.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		3F4E60192855DA0300BFAA65 /* LottieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4E60182855DA0300BFAA65 /* LottieView.swift */; };
 		3F4E601B2855DA3B00BFAA65 /* CompletedTopicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4E601A2855DA3B00BFAA65 /* CompletedTopicView.swift */; };
 		3F4E601D2855DB8C00BFAA65 /* Completion.json in Resources */ = {isa = PBXBuildFile; fileRef = 3F4E601C2855DB8C00BFAA65 /* Completion.json */; };
+		3FFCA107285A134A004102AC /* ReactionEmoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFCA106285A134A004102AC /* ReactionEmoji.swift */; };
 		4A2A97AA2856C7A400EA21C6 /* UIScreenExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2A97A92856C7A400EA21C6 /* UIScreenExtension.swift */; };
 		4A3B249B2855FFC000504486 /* CompletionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3B249A2855FFC000504486 /* CompletionViewModel.swift */; };
 		4AB230F128595CBD0034D3B9 /* CarouselViewConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB230F028595CBD0034D3B9 /* CarouselViewConstants.swift */; };
@@ -64,7 +65,6 @@
 		F2CA7CE42858092F0094B126 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F2CA7CE32858092F0094B126 /* GoogleService-Info.plist */; };
 		F2CA7CFB2858154A0094B126 /* MeetingRoomViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2CA7CFA2858154A0094B126 /* MeetingRoomViewModel.swift */; };
 		F2CA7CFD285825EE0094B126 /* MeetingRoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2CA7CFC285825EE0094B126 /* MeetingRoom.swift */; };
-		F2D58A322859F25600ACFF51 /* CarouselViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D58A312859F25600ACFF51 /* CarouselViewModel.swift */; };
 		F2D707B82849BA6C00DA86FD /* TeamOXYApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D707B72849BA6C00DA86FD /* TeamOXYApp.swift */; };
 		F2D707BC2849BA6D00DA86FD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F2D707BB2849BA6D00DA86FD /* Assets.xcassets */; };
 		F2D707BF2849BA6D00DA86FD /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F2D707BE2849BA6D00DA86FD /* Preview Assets.xcassets */; };
@@ -83,6 +83,7 @@
 		3F4E60182855DA0300BFAA65 /* LottieView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieView.swift; sourceTree = "<group>"; };
 		3F4E601A2855DA3B00BFAA65 /* CompletedTopicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletedTopicView.swift; sourceTree = "<group>"; };
 		3F4E601C2855DB8C00BFAA65 /* Completion.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Completion.json; sourceTree = "<group>"; };
+		3FFCA106285A134A004102AC /* ReactionEmoji.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionEmoji.swift; sourceTree = "<group>"; };
 		4A2A97A92856C7A400EA21C6 /* UIScreenExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScreenExtension.swift; sourceTree = "<group>"; };
 		4A3B249A2855FFC000504486 /* CompletionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionViewModel.swift; sourceTree = "<group>"; };
 		4AB230F028595CBD0034D3B9 /* CarouselViewConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselViewConstants.swift; sourceTree = "<group>"; };
@@ -121,7 +122,6 @@
 		F2CA7CE32858092F0094B126 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		F2CA7CFA2858154A0094B126 /* MeetingRoomViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingRoomViewModel.swift; sourceTree = "<group>"; };
 		F2CA7CFC285825EE0094B126 /* MeetingRoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingRoom.swift; sourceTree = "<group>"; };
-		F2D58A312859F25600ACFF51 /* CarouselViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselViewModel.swift; sourceTree = "<group>"; };
 		F2D707B42849BA6C00DA86FD /* TeamOXY.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TeamOXY.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F2D707B72849BA6C00DA86FD /* TeamOXYApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamOXYApp.swift; sourceTree = "<group>"; };
 		F2D707BB2849BA6D00DA86FD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -259,6 +259,7 @@
 				F225A1E82856CB9800166ECC /* User.swift */,
 				F225A1EA2856CEB200166ECC /* Topic.swift */,
 				F2CA7CFC285825EE0094B126 /* MeetingRoom.swift */,
+				3FFCA106285A134A004102AC /* ReactionEmoji.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -269,7 +270,6 @@
 				4A3B249A2855FFC000504486 /* CompletionViewModel.swift */,
 				F2380A922856EA65004754EE /* EmojiViewModel.swift */,
 				F2CA7CFA2858154A0094B126 /* MeetingRoomViewModel.swift */,
-				F2D58A312859F25600ACFF51 /* CarouselViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -458,9 +458,9 @@
 				F225A1EB2856CEB200166ECC /* Topic.swift in Sources */,
 				F29BED1D28532DC3005B4A1B /* RoundButton.swift in Sources */,
 				F2CA7CFB2858154A0094B126 /* MeetingRoomViewModel.swift in Sources */,
+				3FFCA107285A134A004102AC /* ReactionEmoji.swift in Sources */,
 				4A3B249B2855FFC000504486 /* CompletionViewModel.swift in Sources */,
 				F29BED232853B24C005B4A1B /* CreateMeetingRoomView.swift in Sources */,
-				F2D58A322859F25600ACFF51 /* CarouselViewModel.swift in Sources */,
 				F2380A8B2856D500004754EE /* FirebaseManager.swift in Sources */,
 				21830A0B2858642300B279B6 /* HapticManager.swift in Sources */,
 				3F4E60092853A30300BFAA65 /* EmojiReactionView.swift in Sources */,

--- a/TeamOXY/TeamOXY/Model/ReactionEmoji.swift
+++ b/TeamOXY/TeamOXY/Model/ReactionEmoji.swift
@@ -1,0 +1,14 @@
+//
+//  ReactionEmoji.swift
+//  TeamOXY
+//
+//  Created by ParkJunHyuk on 2022/06/15.
+//
+
+import Foundation
+
+struct ReactionEmoji : Identifiable, Codable {
+    var id = UUID().uuidString
+    var reaction_num : String
+    var reaction_count : Int
+}

--- a/TeamOXY/TeamOXY/View/MeetingRoom/EmojiReactionView.swift
+++ b/TeamOXY/TeamOXY/View/MeetingRoom/EmojiReactionView.swift
@@ -39,7 +39,7 @@ struct EmojiReactionView: View {
                                     
                                     Button(action: {
                                         
-                                        viewModel.emojiCountPlus(emoji)
+                                        viewModel.update(emoji)
 
                                     }){
                                         Text(emoji)
@@ -73,19 +73,22 @@ struct EmojiReactionView: View {
                     
                     ConfettiCannon(counter: $viewModel.emojiCount_9, num: 5, confettis: [.text("🤭")], confettiSize: 30, radius: 300.0)
                 }
+            
+                ConfettiCannon(counter: $viewModel.emojiCount_10, num: 5, confettis: [.text("🥱")], confettiSize: 30, radius: 300.0)
+            
+                ConfettiCannon(counter: $viewModel.emojiCount_11, num: 5, confettis: [.text("👀")], confettiSize: 30, radius: 300.0)
                 
-                    ConfettiCannon(counter: $viewModel.emojiCount_10, num: 5, confettis: [.text("🥱")], confettiSize: 30, radius: 300.0)
+                ConfettiCannon(counter: $viewModel.emojiCount_12, num: 5, confettis: [.text("✅")], confettiSize: 30, radius: 300.0)
                 
-                    ConfettiCannon(counter: $viewModel.emojiCount_11, num: 5, confettis: [.text("👀")], confettiSize: 30, radius: 300.0)
-                    
-                    ConfettiCannon(counter: $viewModel.emojiCount_12, num: 5, confettis: [.text("✅")], confettiSize: 30, radius: 300.0)
-                    
-                    ConfettiCannon(counter: $viewModel.emojiCount_13, num: 5, confettis: [.text("🙅")], confettiSize: 30, radius: 300.0)
-                    
-                    ConfettiCannon(counter: $viewModel.emojiCount_14, num: 5, confettis: [.text("🎉")], confettiSize: 30, radius: 300.0)
-                    
-                    ConfettiCannon(counter: $viewModel.emojiCount_15, num: 5, confettis: [.text("😂")], confettiSize: 30, radius: 300.0)
-            }
+                ConfettiCannon(counter: $viewModel.emojiCount_13, num: 5, confettis: [.text("🙅")], confettiSize: 30, radius: 300.0)
+                
+                ConfettiCannon(counter: $viewModel.emojiCount_14, num: 5, confettis: [.text("🎉")], confettiSize: 30, radius: 300.0)
+                
+                ConfettiCannon(counter: $viewModel.emojiCount_15, num: 5, confettis: [.text("😂")], confettiSize: 30, radius: 300.0)
+        }
+        .onAppear{
+            viewModel.setDocument(emojis)
+        }
     }
 }
 

--- a/TeamOXY/TeamOXY/ViewModel/EmojiViewModel.swift
+++ b/TeamOXY/TeamOXY/ViewModel/EmojiViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Firebase
 
 class EmojieViewModel : ObservableObject{
     @Published var emojiCount_1 : Int
@@ -24,6 +25,22 @@ class EmojieViewModel : ObservableObject{
     @Published var emojiCount_14 : Int
     @Published var emojiCount_15 : Int
     
+    // 로딩시 클래스 초기화로 애니메이션 작동을 막기 위해 변수 설정
+    @Published var isLoading : Bool = false
+    
+    // FireStore에서 데이터를 받아오고 저장할 변수
+    @Published var messages : [ReactionEmoji] = []
+    
+    private var db = Firestore.firestore()
+    
+    let emojis = ["🤔","👎","👍","🤩","🫠", "🔥","❤️","😱","🤭","🥱","👀","✅","🙅","🎉","😂"]
+    
+    // FireStore Collection, Document 이름
+    let selectedCollection1 = "rooms"
+    let selectedDocument1 = "익명의 호랑이 방"
+    let selecetedCollection2 = "reactionEmojis"
+    
+    
     init() {
         self.emojiCount_1 = 0
         self.emojiCount_2 = 0
@@ -41,72 +58,361 @@ class EmojieViewModel : ObservableObject{
         self.emojiCount_14 = 0
         self.emojiCount_15 = 0
         
+        receiveEmojiCount()
+        
+        // 0.5 초의 차이를 두어 뷰가 로드 되자마자 이모지가 터지는 애니메이션을 막음
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.isLoading = true
+        }
     }
     
-    func emojiCountPlus (_ emoji : String) {
-        switch emoji {
-        case "🤔" :
-            self.emojiCount_1 += 1
-            print(emojiCount_1)
-            
-        case "👎" :
-            self.emojiCount_2 += 1
-            print(emojiCount_2)
-            
-        case "👍" :
-            self.emojiCount_3 += 1
-            print(emojiCount_3)
-            
-        case "🤩" :
-            self.emojiCount_4 += 1
-            print(emojiCount_4)
-            
-        case "🫠" :
-            self.emojiCount_5 += 1
-            print(emojiCount_5)
-            
-        case "🔥" :
-            self.emojiCount_6 += 1
-            print(emojiCount_6)
-            
-        case "❤️" :
-            self.emojiCount_7 += 1
-            print(emojiCount_7)
-            
-        case "😱" :
-            self.emojiCount_8 += 1
-            print(emojiCount_8)
-            
-        case "🤭" :
-            self.emojiCount_9 += 1
-            print(emojiCount_9)
-            
-        case "🥱" :
-            self.emojiCount_10 += 1
-            print(emojiCount_10)
-            
-        case "👀" :
-            self.emojiCount_11 += 1
-            print(emojiCount_11)
+    // Firestore Document 를 설정하기 위한 함수
+    func setDocument (_ emojis : [String]) {
         
-        case "✅" :
-            self.emojiCount_12 += 1
-            print(emojiCount_12)
-            
-        case "🙅" :
-            self.emojiCount_13 += 1
-            print(emojiCount_13)
-            
-        case "🎉" :
-            self.emojiCount_14 += 1
-            print(emojiCount_14)
-                  
-        case "😂" :
-            self.emojiCount_15 += 1
-            print(emojiCount_15)
-            
-        default :
-            print("잘못 눌렀습니다.")
+        print("setup")
+        
+        for emoji in emojis {
+            db.collection("\(selectedCollection1)").document("\(selectedDocument1)").collection("\(selecetedCollection2)").document("\(emoji)").setData([
+                "reaction_num" : emoji,
+                "reaction_count" : 0 // FieldValue.increment(Int64(1))
+            ]) { err in
+                if let err = err {
+                    print("Error writing document: \(err)")
+                } else {
+                    print("Document successfully written!")
+                }
+            }
         }
+    }
+    
+    // Firestore 데이터 불러오기 ( 데이터가 잘들어가는지 확인 )
+    func getEmojiCount() {
+        
+        db.collection("\(selectedCollection1)").document("\(selectedDocument1)").collection("\(selecetedCollection2)").addSnapshotListener {(querySnapshot, error) in
+            guard let documents = querySnapshot?.documents else {
+                print("No documents")
+                return
+            }
+            
+            self.messages = documents.map { (QueryDocumentSnapshot) -> ReactionEmoji in
+                let data = QueryDocumentSnapshot.data()
+                
+                // 데이터는 string 에서 any로 매핑 된다 즉 , any에서 올바른 유형으로 변환 시켜야 한다
+                let reaction_num = data["reaction_num"] as? String ?? ""
+                let reaction_count = data["reaction_count"] as? Int ?? 0
+                
+                return ReactionEmoji(reaction_num: reaction_num, reaction_count: reaction_count)
+            }
+        }
+    }
+    
+    // FireStore 에 필드 값을 1씩 증가 시키기 -> 값이 변할때 애니메이션이 동작
+    func update( _ emoji : String) {
+        
+        print("업데이트")
+        
+        let emojiCountUpdate = db.collection("\(selectedCollection1)").document("\(selectedDocument1)").collection("\(selecetedCollection2)").document("\(emoji)")
+        
+        emojiCountUpdate.updateData([
+            "reaction_num" : emoji,
+            "reaction_count" : FieldValue.increment(Int64(1))
+        ])
+        
+        getEmojiCount()
+    }
+    
+    // FireStore 에 변경사항이 있을때 자동으로 실행
+    func receiveEmojiCount() {
+
+        print("변경사항 발생")
+
+        db.collection("\(selectedCollection1)").document("\(selectedDocument1)").collection("\(selecetedCollection2)").document("🤔")
+            .addSnapshotListener { documentSnapshot, error in
+              guard let document = documentSnapshot else {
+                print("Error fetching document: \(error!)")
+                return
+              }
+              guard let data = document.data() else {
+                print("Document data was empty.")
+                return
+              }
+
+                print("\(self.isLoading)")
+
+                if self.isLoading {
+                    let reaction_count = data["reaction_count"] as? Int ?? 0
+
+
+                    self.emojiCount_1 = reaction_count
+                    print("첫번째 : \(self.emojiCount_1)")
+                }
+            }
+
+        db.collection("\(selectedCollection1)").document("\(selectedDocument1)").collection("\(selecetedCollection2)").document("👎")
+            .addSnapshotListener { documentSnapshot, error in
+              guard let document = documentSnapshot else {
+                print("Error fetching document: \(error!)")
+                return
+              }
+              guard let data = document.data() else {
+                print("Document data was empty.")
+                return
+              }
+
+
+                if self.isLoading {
+                    let reaction_count = data["reaction_count"] as? Int ?? 0
+
+                    self.emojiCount_2 = reaction_count
+                    print("두번째 : \(self.emojiCount_2)")
+                }
+            }
+
+        db.collection("\(selectedCollection1)").document("\(selectedDocument1)").collection("\(selecetedCollection2)").document("👍")
+            .addSnapshotListener { documentSnapshot, error in
+              guard let document = documentSnapshot else {
+                print("Error fetching document: \(error!)")
+                return
+              }
+              guard let data = document.data() else {
+                print("Document data was empty.")
+                return
+              }
+
+                if self.isLoading {
+                    let reaction_count = data["reaction_count"] as? Int ?? 0
+
+                    self.emojiCount_3 = reaction_count
+                    print("세번째 : \(self.emojiCount_3)")
+                }
+            }
+
+        db.collection("\(selectedCollection1)").document("\(selectedDocument1)").collection("\(selecetedCollection2)").document("🤩")
+            .addSnapshotListener { documentSnapshot, error in
+              guard let document = documentSnapshot else {
+                print("Error fetching document: \(error!)")
+                return
+              }
+              guard let data = document.data() else {
+                print("Document data was empty.")
+                return
+              }
+
+                if self.isLoading {
+                    let reaction_count = data["reaction_count"] as? Int ?? 0
+
+                    self.emojiCount_4 = reaction_count
+                    print("네번째 : \(self.emojiCount_4)")
+                }
+            }
+
+        db.collection("\(selectedCollection1)").document("\(selectedDocument1)").collection("\(selecetedCollection2)").document("🫠")
+            .addSnapshotListener { documentSnapshot, error in
+              guard let document = documentSnapshot else {
+                print("Error fetching document: \(error!)")
+                return
+              }
+              guard let data = document.data() else {
+                print("Document data was empty.")
+                return
+              }
+
+                if self.isLoading {
+                    let reaction_count = data["reaction_count"] as? Int ?? 0
+
+                    self.emojiCount_5 = reaction_count
+                    print("다섯번째 : \(self.emojiCount_5)")
+                }
+            }
+
+        db.collection("\(selectedCollection1)").document("\(selectedDocument1)").collection("\(selecetedCollection2)").document("🔥")
+            .addSnapshotListener { documentSnapshot, error in
+              guard let document = documentSnapshot else {
+                print("Error fetching document: \(error!)")
+                return
+              }
+              guard let data = document.data() else {
+                print("Document data was empty.")
+                return
+              }
+
+                if self.isLoading {
+                    let reaction_count = data["reaction_count"] as? Int ?? 0
+
+                    self.emojiCount_6 = reaction_count
+                    print("여섯번째 : \(self.emojiCount_6)")
+                }
+            }
+
+        db.collection("\(selectedCollection1)").document("\(selectedDocument1)").collection("\(selecetedCollection2)").document("❤️")
+            .addSnapshotListener { documentSnapshot, error in
+              guard let document = documentSnapshot else {
+                print("Error fetching document: \(error!)")
+                return
+              }
+              guard let data = document.data() else {
+                print("Document data was empty.")
+                return
+              }
+
+                if self.isLoading {
+                    let reaction_count = data["reaction_count"] as? Int ?? 0
+
+                    self.emojiCount_7 = reaction_count
+                    print("일곱번째 : \(self.emojiCount_7)")
+                }
+            }
+
+        db.collection("\(selectedCollection1)").document("\(selectedDocument1)").collection("\(selecetedCollection2)").document("😱")
+            .addSnapshotListener { documentSnapshot, error in
+              guard let document = documentSnapshot else {
+                print("Error fetching document: \(error!)")
+                return
+              }
+              guard let data = document.data() else {
+                print("Document data was empty.")
+                return
+              }
+
+                if self.isLoading {
+                    let reaction_count = data["reaction_count"] as? Int ?? 0
+
+                    self.emojiCount_8 = reaction_count
+                    print("여덟번째 : \(self.emojiCount_8)")
+                }
+            }
+
+        db.collection("\(selectedCollection1)").document("\(selectedDocument1)").collection("\(selecetedCollection2)").document("🤭")
+            .addSnapshotListener { documentSnapshot, error in
+              guard let document = documentSnapshot else {
+                print("Error fetching document: \(error!)")
+                return
+              }
+              guard let data = document.data() else {
+                print("Document data was empty.")
+                return
+              }
+
+                if self.isLoading {
+                    let reaction_count = data["reaction_count"] as? Int ?? 0
+
+                    self.emojiCount_9 = reaction_count
+                    print("아홉번째 : \(self.emojiCount_9)")
+                }
+            }
+
+        db.collection("\(selectedCollection1)").document("\(selectedDocument1)").collection("\(selecetedCollection2)").document("🥱")
+            .addSnapshotListener { documentSnapshot, error in
+              guard let document = documentSnapshot else {
+                print("Error fetching document: \(error!)")
+                return
+              }
+              guard let data = document.data() else {
+                print("Document data was empty.")
+                return
+              }
+
+                if self.isLoading {
+                    let reaction_count = data["reaction_count"] as? Int ?? 0
+
+                    self.emojiCount_10 = reaction_count
+                    print("열번째 : \(self.emojiCount_10)")
+                }
+            }
+
+        db.collection("\(selectedCollection1)").document("\(selectedDocument1)").collection("\(selecetedCollection2)").document("👀")
+            .addSnapshotListener { documentSnapshot, error in
+              guard let document = documentSnapshot else {
+                print("Error fetching document: \(error!)")
+                return
+              }
+              guard let data = document.data() else {
+                print("Document data was empty.")
+                return
+              }
+
+                if self.isLoading {
+                    let reaction_count = data["reaction_count"] as? Int ?? 0
+
+                    self.emojiCount_11 = reaction_count
+                    print("열한번째 : \(self.emojiCount_11)")
+                }
+            }
+
+        db.collection("\(selectedCollection1)").document("\(selectedDocument1)").collection("\(selecetedCollection2)").document("✅")
+            .addSnapshotListener { documentSnapshot, error in
+              guard let document = documentSnapshot else {
+                print("Error fetching document: \(error!)")
+                return
+              }
+              guard let data = document.data() else {
+                print("Document data was empty.")
+                return
+              }
+
+                if self.isLoading {
+                    let reaction_count = data["reaction_count"] as? Int ?? 0
+
+                    self.emojiCount_12 = reaction_count
+                    print("열두번째 : \(self.emojiCount_12)")
+                }
+            }
+
+        db.collection("\(selectedCollection1)").document("\(selectedDocument1)").collection("\(selecetedCollection2)").document("🙅")
+            .addSnapshotListener { documentSnapshot, error in
+              guard let document = documentSnapshot else {
+                print("Error fetching document: \(error!)")
+                return
+              }
+              guard let data = document.data() else {
+                print("Document data was empty.")
+                return
+              }
+
+                if self.isLoading {
+                    let reaction_count = data["reaction_count"] as? Int ?? 0
+
+                    self.emojiCount_13 = reaction_count
+                    print("열세번째 : \(self.emojiCount_13)")
+                }
+            }
+
+        db.collection("\(selectedCollection1)").document("\(selectedDocument1)").collection("\(selecetedCollection2)").document("🎉")
+            .addSnapshotListener { documentSnapshot, error in
+              guard let document = documentSnapshot else {
+                print("Error fetching document: \(error!)")
+                return
+              }
+              guard let data = document.data() else {
+                print("Document data was empty.")
+                return
+              }
+
+                if self.isLoading {
+                    let reaction_count = data["reaction_count"] as? Int ?? 0
+
+                    self.emojiCount_14 = reaction_count
+                    print("열네번째 : \(self.emojiCount_14)")
+                }
+            }
+
+        db.collection("\(selectedCollection1)").document("\(selectedDocument1)").collection("\(selecetedCollection2)").document("😂")
+            .addSnapshotListener { documentSnapshot, error in
+              guard let document = documentSnapshot else {
+                print("Error fetching document: \(error!)")
+                return
+              }
+              guard let data = document.data() else {
+                print("Document data was empty.")
+                return
+              }
+
+                if self.isLoading {
+                    let reaction_count = data["reaction_count"] as? Int ?? 0
+
+                    self.emojiCount_15 = reaction_count
+                    print("열다섯번째 : \(self.emojiCount_15)")
+                }
+            }
     }
 }


### PR DESCRIPTION
## 작업 내용

### `EmojiViewModel` 의 Count 증가에 대한 로직 수정 

#### 원래의 로직
   - `EmojiReactionView` 에서 버튼 누를 시 `EmojiViewModel` 의 해당 `EmojiCount` 이 1 증가
   - `ConfettiSwiftUI` 로직으로 인해 값이 변경되었을 때 애니메이션 수행
   - FireStore 에도 해당 이모지의 필드 값을 1 증가 
   - 다른 디바이스에서는 FireStore 의 값 변화를 인지 `EmojiViewModel` 의 해당 `EmojiCount` 를 1 증가
   - `ConfettiSwiftUI` 로직으로 인해 값이 변경되었을 때 애니메이션 수행
   - `EmojiCount` 이 2번 1이 증가 되므로 원래의 디바이스에 애니메이션이 한번 더 수행 되는 문제 발생

#### 바뀐 로직
   - `EmojiReactionView` 에서 버튼 누를 시 `EmojiViewModel` 의 `update()` 통해 FireStore 에 해당 이모지 필드 값 1 증가
   -  2개의 디바이스에서는 FireStore 의 값 변화를 인지 `EmojiViewModel` 의 해당 `EmojiCount` 를 1 증가
   - `ConfettiSwiftUI` 로직으로 인해 값이 변경되었을 때 애니메이션 수행
   - 어떤 디바이스에서든 애니메이션은 1번 동작

#### 또다른 변경점
   - View 가 다시 로드 될 때 Class 의 초기화로 인해 애니메이션이 동작하게 되는 문제점 발생
   - Class 의 초기화로 인한 애니메이션 동작을 막기 위한 상태를 감지하는 `isLoading` 변수 추가
   - 초기화시 `receiveEmojiCount()` 가 실행되고 `isLoading` 가 바뀌어야 하므로 `DispatchQueue.main.asyncAfter` 설정
   - View 로드시 애니메이션 실행되는 문제점 수정


## 리뷰 포인트
-  `EmojiViewModel` 의 `receiveEmojiCount()`
-  `EmojiViewModel` 의 `isLoading`


## 다음으로 진행될 작업

## 질문


## References
