### PR TITLE
[Merge] multi picker 터치영역 오류 해결 및 알람 기본 설정 변경

### DIFF
--- a/TeamOXY/TeamOXY.xcodeproj/project.pbxproj
+++ b/TeamOXY/TeamOXY.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		15634FA72854EB3F009264BF /* BreakTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15634FA42854EB3F009264BF /* BreakTimeView.swift */; };
 		15634FA82854EB3F009264BF /* CircularTimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15634FA52854EB3F009264BF /* CircularTimerView.swift */; };
 		15634FA92854EB3F009264BF /* TimeSetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15634FA62854EB3F009264BF /* TimeSetView.swift */; };
+		15D47563285B607D00D4704C /* UIPickerView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D47562285B607D00D4704C /* UIPickerView+.swift */; };
 		212E5CE22853280400E10FF4 /* MeetingRoomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212E5CE12853280400E10FF4 /* MeetingRoomView.swift */; };
 		21812E8428557D380023463C /* FinishTopicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21812E8328557D380023463C /* FinishTopicView.swift */; };
 		21830A0B2858642300B279B6 /* HapticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21830A0A2858642300B279B6 /* HapticManager.swift */; };
@@ -77,6 +78,7 @@
 		15634FA42854EB3F009264BF /* BreakTimeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BreakTimeView.swift; sourceTree = "<group>"; };
 		15634FA52854EB3F009264BF /* CircularTimerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CircularTimerView.swift; sourceTree = "<group>"; };
 		15634FA62854EB3F009264BF /* TimeSetView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeSetView.swift; sourceTree = "<group>"; };
+		15D47562285B607D00D4704C /* UIPickerView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIPickerView+.swift"; sourceTree = "<group>"; };
 		212E5CE12853280400E10FF4 /* MeetingRoomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingRoomView.swift; sourceTree = "<group>"; };
 		21812E8328557D380023463C /* FinishTopicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishTopicView.swift; sourceTree = "<group>"; };
 		21830A0A2858642300B279B6 /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
@@ -241,6 +243,7 @@
 				F29BED1E28533CBC005B4A1B /* String+ButtonImageName.swift */,
 				4A2A97A92856C7A400EA21C6 /* UIScreenExtension.swift */,
 				F2380A902856E010004754EE /* TypographyExtension.swift */,
+				15D47562285B607D00D4704C /* UIPickerView+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -314,7 +317,6 @@
 			path = QRCode;
 			sourceTree = "<group>";
 		};
-
 		F2D58A41285AAF1C00ACFF51 /* Config */ = {
 			isa = PBXGroup;
 			children = (
@@ -343,9 +345,7 @@
 		F2D707B62849BA6C00DA86FD /* TeamOXY */ = {
 			isa = PBXGroup;
 			children = (
-
 				F2D58A41285AAF1C00ACFF51 /* Config */,
-
 				F2CA7CE32858092F0094B126 /* GoogleService-Info.plist */,
 				F225A1ED2856D4BC00166ECC /* Utils */,
 				F29BED1B28532DB8005B4A1B /* Components */,
@@ -475,6 +475,7 @@
 				F29BED2528543123005B4A1B /* FieldType.swift in Sources */,
 				4AC8DEEB2854F20E00500E0A /* CarouselView.swift in Sources */,
 				7BFBD2E22856C33B00E5D98C /* OnboardingView.swift in Sources */,
+				15D47563285B607D00D4704C /* UIPickerView+.swift in Sources */,
 				21812E8428557D380023463C /* FinishTopicView.swift in Sources */,
 				F225A1E92856CB9800166ECC /* User.swift in Sources */,
 				F225A1EB2856CEB200166ECC /* Topic.swift in Sources */,

--- a/TeamOXY/TeamOXY/Extensions/UIPickerView+.swift
+++ b/TeamOXY/TeamOXY/Extensions/UIPickerView+.swift
@@ -1,0 +1,14 @@
+//
+//  UIPickerView+.swift
+//  TeamOXY
+//
+//  Created by yeekim on 2022/06/16.
+//
+
+import SwiftUI
+
+extension UIPickerView {
+    open override var intrinsicContentSize: CGSize {
+        return CGSize(width: UIView.noIntrinsicMetric, height: super.intrinsicContentSize.height)
+    }
+}

--- a/TeamOXY/TeamOXY/View/BreakTime/BreakTimeView.swift
+++ b/TeamOXY/TeamOXY/View/BreakTime/BreakTimeView.swift
@@ -13,7 +13,7 @@ struct BreakTimeView: View {
     @State var countTo: Int
     
     // 알람 설정
-    @State private var isNotification = false
+    @State private var isNotification = true
     
     var body: some View {
         ZStack {
@@ -45,7 +45,7 @@ struct BreakTimeView: View {
             }
         }
         .navigationBarTitle("쉬는 시간", displayMode: .inline)
-//        .navigationBarBackButtonHidden(true)
+        .navigationBarBackButtonHidden(true)
     }
     
     func displayFinish() -> String{


### PR DESCRIPTION
Resolves: #111
Related: #110

## 작업 내용
TimeSetView의 multi picker 터치 영역 오류 UIPickerView 익스텐션으로 해결하였습니다.
BreakTimeView의 알람 기본 설정이 off 여서 on으로 변경하였습니다. 또한 해당 화면에서 뒤로가기 버튼을 hidden하였습니다. 

## 리뷰 포인트
UIPickerView 파일 생성, References에 첨부한 포럼을 참고하였습니다. 

## 다음으로 진행될 작업

## 질문

## References
https://developer.apple.com/forums/thread/687986