### PR TITLE
[Merge] #123 topic & timer push notification

### DIFF
--- a/TeamOXY/TeamOXY.xcodeproj/project.pbxproj
+++ b/TeamOXY/TeamOXY.xcodeproj/project.pbxproj
@@ -27,6 +27,10 @@
 		3FFCA113285C6E95004102AC /* AnonymousLoginLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFCA112285C6E95004102AC /* AnonymousLoginLoadingView.swift */; };
 		4A2A97AA2856C7A400EA21C6 /* UIScreenExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2A97A92856C7A400EA21C6 /* UIScreenExtension.swift */; };
 		4A3B249B2855FFC000504486 /* CompletionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3B249A2855FFC000504486 /* CompletionViewModel.swift */; };
+		4A99E811285EAA8900CE73EE /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A99E810285EAA8900CE73EE /* NotificationManager.swift */; };
+		4A99E813285EAB7900CE73EE /* TimeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A99E812285EAB7900CE73EE /* TimeModel.swift */; };
+		4A99E815285EACA300CE73EE /* TimerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A99E814285EACA300CE73EE /* TimerViewModel.swift */; };
+		4A99E817285EACF500CE73EE /* TokenModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A99E816285EACF500CE73EE /* TokenModel.swift */; };
 		4AB230F128595CBD0034D3B9 /* CarouselViewConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB230F028595CBD0034D3B9 /* CarouselViewConstants.swift */; };
 		4AC8DEEB2854F20E00500E0A /* CarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC8DEEA2854F20E00500E0A /* CarouselView.swift */; };
 		7BC5EFB02851E5C0004A27B5 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7BC5EFAF2851E5C0004A27B5 /* Colors.xcassets */; };
@@ -71,8 +75,8 @@
 		F2CA7CFD285825EE0094B126 /* MeetingRoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2CA7CFC285825EE0094B126 /* MeetingRoom.swift */; };
 		F2D58A342859F42F00ACFF51 /* CarouselViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D58A332859F42F00ACFF51 /* CarouselViewModel.swift */; };
 		F2D58A36285A002800ACFF51 /* SendNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D58A35285A002800ACFF51 /* SendNotification.swift */; };
-		F2D58A44285AAF3100ACFF51 /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = F2D58A42285AAF3100ACFF51 /* Debug.xcconfig */; };
-		F2D58A45285AAF3100ACFF51 /* Production.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = F2D58A43285AAF3100ACFF51 /* Production.xcconfig */; };
+		F2D58A44285AAF3100ACFF51 /* (null) in Resources */ = {isa = PBXBuildFile; };
+		F2D58A45285AAF3100ACFF51 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		F2D707B82849BA6C00DA86FD /* TeamOXYApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D707B72849BA6C00DA86FD /* TeamOXYApp.swift */; };
 		F2D707BC2849BA6D00DA86FD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F2D707BB2849BA6D00DA86FD /* Assets.xcassets */; };
 		F2D707BF2849BA6D00DA86FD /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F2D707BE2849BA6D00DA86FD /* Preview Assets.xcassets */; };
@@ -97,6 +101,10 @@
 		3FFCA112285C6E95004102AC /* AnonymousLoginLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnonymousLoginLoadingView.swift; sourceTree = "<group>"; };
 		4A2A97A92856C7A400EA21C6 /* UIScreenExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScreenExtension.swift; sourceTree = "<group>"; };
 		4A3B249A2855FFC000504486 /* CompletionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionViewModel.swift; sourceTree = "<group>"; };
+		4A99E810285EAA8900CE73EE /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
+		4A99E812285EAB7900CE73EE /* TimeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeModel.swift; sourceTree = "<group>"; };
+		4A99E814285EACA300CE73EE /* TimerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerViewModel.swift; sourceTree = "<group>"; };
+		4A99E816285EACF500CE73EE /* TokenModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenModel.swift; sourceTree = "<group>"; };
 		4AB230F028595CBD0034D3B9 /* CarouselViewConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselViewConstants.swift; sourceTree = "<group>"; };
 		4AC8DEEA2854F20E00500E0A /* CarouselView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CarouselView.swift; sourceTree = "<group>"; };
 		7BC5EFAF2851E5C0004A27B5 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
@@ -136,9 +144,6 @@
 		F2CA7CFC285825EE0094B126 /* MeetingRoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingRoom.swift; sourceTree = "<group>"; };
 		F2D58A332859F42F00ACFF51 /* CarouselViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselViewModel.swift; sourceTree = "<group>"; };
 		F2D58A35285A002800ACFF51 /* SendNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendNotification.swift; sourceTree = "<group>"; };
-
-		F2D58A38285A015600ACFF51 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
-		F2D58A39285A016C00ACFF51 /* Production.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Production.xcconfig; sourceTree = "<group>"; };
 		F2D707B42849BA6C00DA86FD /* TeamOXY.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TeamOXY.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F2D707B72849BA6C00DA86FD /* TeamOXYApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamOXYApp.swift; sourceTree = "<group>"; };
 		F2D707BB2849BA6D00DA86FD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -192,6 +197,7 @@
 				F2380A8E2856D633004754EE /* generateRandomNickname.swift */,
 				21830A0A2858642300B279B6 /* HapticManager.swift */,
 				F2D58A35285A002800ACFF51 /* SendNotification.swift */,
+				4A99E810285EAA8900CE73EE /* NotificationManager.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -254,11 +260,8 @@
 				F29BED1E28533CBC005B4A1B /* String+ButtonImageName.swift */,
 				4A2A97A92856C7A400EA21C6 /* UIScreenExtension.swift */,
 				F2380A902856E010004754EE /* TypographyExtension.swift */,
-
 				F2412911285B1279001DE655 /* String+TopicLableExtension.swift */,
-
 				15D47562285B607D00D4704C /* UIPickerView+.swift */,
-
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -285,6 +288,8 @@
 				F225A1EA2856CEB200166ECC /* Topic.swift */,
 				F2CA7CFC285825EE0094B126 /* MeetingRoom.swift */,
 				3FFCA106285A134A004102AC /* ReactionEmoji.swift */,
+				4A99E812285EAB7900CE73EE /* TimeModel.swift */,
+				4A99E816285EACF500CE73EE /* TokenModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -296,6 +301,7 @@
 				F2380A922856EA65004754EE /* EmojiViewModel.swift */,
 				F2CA7CFA2858154A0094B126 /* MeetingRoomViewModel.swift */,
 				F2D58A332859F42F00ACFF51 /* CarouselViewModel.swift */,
+				4A99E814285EACA300CE73EE /* TimerViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -333,15 +339,6 @@
 			path = QRCode;
 			sourceTree = "<group>";
 		};
-		F2D58A41285AAF1C00ACFF51 /* Config */ = {
-			isa = PBXGroup;
-			children = (
-				F2D58A42285AAF3100ACFF51 /* Debug.xcconfig */,
-				F2D58A43285AAF3100ACFF51 /* Production.xcconfig */,
-			);
-			path = Config;
-			sourceTree = "<group>";
-		};
 		F2D707AB2849BA6C00DA86FD = {
 			isa = PBXGroup;
 			children = (
@@ -361,7 +358,6 @@
 		F2D707B62849BA6C00DA86FD /* TeamOXY */ = {
 			isa = PBXGroup;
 			children = (
-				F2D58A41285AAF1C00ACFF51 /* Config */,
 				F2CA7CE32858092F0094B126 /* GoogleService-Info.plist */,
 				F225A1ED2856D4BC00166ECC /* Utils */,
 				F29BED1B28532DB8005B4A1B /* Components */,
@@ -470,8 +466,8 @@
 				F29BECED285217A9005B4A1B /* Pretendard-ExtraLight.otf in Resources */,
 				F29BECEA285217A9005B4A1B /* Pretendard-ExtraBold.otf in Resources */,
 				F29BECE6285217A9005B4A1B /* Pretendard-Medium.otf in Resources */,
-				F2D58A44285AAF3100ACFF51 /* Debug.xcconfig in Resources */,
-				F2D58A45285AAF3100ACFF51 /* Production.xcconfig in Resources */,
+				F2D58A44285AAF3100ACFF51 /* (null) in Resources */,
+				F2D58A45285AAF3100ACFF51 /* (null) in Resources */,
 				3FFCA111285C454D004102AC /* MC2_Lotti.json in Resources */,
 				F29BECEC285217A9005B4A1B /* Pretendard-Regular.otf in Resources */,
 				F29BECE9285217A9005B4A1B /* Pretendard-SemiBold.otf in Resources */,
@@ -493,6 +489,7 @@
 				4AC8DEEB2854F20E00500E0A /* CarouselView.swift in Sources */,
 				7BFBD2E22856C33B00E5D98C /* OnboardingView.swift in Sources */,
 				15D47563285B607D00D4704C /* UIPickerView+.swift in Sources */,
+				4A99E813285EAB7900CE73EE /* TimeModel.swift in Sources */,
 				21812E8428557D380023463C /* FinishTopicView.swift in Sources */,
 				F225A1E92856CB9800166ECC /* User.swift in Sources */,
 				F225A1EB2856CEB200166ECC /* Topic.swift in Sources */,
@@ -501,6 +498,8 @@
 				3FFCA113285C6E95004102AC /* AnonymousLoginLoadingView.swift in Sources */,
 				3FFCA107285A134A004102AC /* ReactionEmoji.swift in Sources */,
 				4A3B249B2855FFC000504486 /* CompletionViewModel.swift in Sources */,
+				4A99E817285EACF500CE73EE /* TokenModel.swift in Sources */,
+				4A99E811285EAA8900CE73EE /* NotificationManager.swift in Sources */,
 				F2412912285B1279001DE655 /* String+TopicLableExtension.swift in Sources */,
 				F29BED232853B24C005B4A1B /* CreateMeetingRoomView.swift in Sources */,
 				F2D58A342859F42F00ACFF51 /* CarouselViewModel.swift in Sources */,
@@ -518,6 +517,7 @@
 				15634FA92854EB3F009264BF /* TimeSetView.swift in Sources */,
 				3F4E601B2855DA3B00BFAA65 /* CompletedTopicView.swift in Sources */,
 				21D2547B2852D21100E3EADC /* TestCardView.swift in Sources */,
+				4A99E815285EACA300CE73EE /* TimerViewModel.swift in Sources */,
 				F2CA7CFD285825EE0094B126 /* MeetingRoom.swift in Sources */,
 				F225A1E72856C89A00166ECC /* Reaction.swift in Sources */,
 				F2D707B82849BA6C00DA86FD /* TeamOXYApp.swift in Sources */,
@@ -655,7 +655,6 @@
 		};
 		F2D707C32849BA6D00DA86FD /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F2D58A42285AAF3100ACFF51 /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -689,7 +688,6 @@
 		};
 		F2D707C42849BA6D00DA86FD /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F2D58A43285AAF3100ACFF51 /* Production.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/TeamOXY/TeamOXY/Constants/FirebaseConstants.swift
+++ b/TeamOXY/TeamOXY/Constants/FirebaseConstants.swift
@@ -29,10 +29,14 @@ struct FirebaseConstants {
     static let timestamp = "timestamp"
     
     // Timer
-    
+    static let timers = "timers"
+    static let setTime = "setTime"
+    static let isAvailable = "isAvailable"
     // Collection Name
     static let rooms = "rooms"
     static let users = "users"
     static let reactions = "reactions"
     static let topics = "topics"
+    
+    
 }

--- a/TeamOXY/TeamOXY/Model/TimeModel.swift
+++ b/TeamOXY/TeamOXY/Model/TimeModel.swift
@@ -1,0 +1,24 @@
+//
+//  Timer.swift
+//  TeamOXY
+//
+//  Created by Minkyeong Ko on 2022/06/16.
+//
+import Foundation
+
+import Firebase
+import FirebaseFirestore
+import FirebaseFirestoreSwift
+
+class TimeModel: Codable, Identifiable {
+    @DocumentID var id: String?
+    
+    // 설정된 쉬는 시간
+    let timestamp: Int
+    
+    // 타이머 설정 당시 시간
+    let setTime: Date
+    
+    // 타이머 사용가능 여부
+    let isAvailable: Bool
+}

--- a/TeamOXY/TeamOXY/Model/TokenModel.swift
+++ b/TeamOXY/TeamOXY/Model/TokenModel.swift
@@ -1,0 +1,16 @@
+//
+//  TokenModel.swift
+//  TeamOXY
+//
+//  Created by 최동권 on 2022/06/19.
+//
+
+import Foundation
+
+class TokenModel {
+    static let shared = TokenModel()
+    var token: String?
+
+    private init() {}
+
+}

--- a/TeamOXY/TeamOXY/Model/Topic.swift
+++ b/TeamOXY/TeamOXY/Model/Topic.swift
@@ -35,7 +35,7 @@
 ////        self.fromId = data["fromId"] as? String ?? ""
 ////        self.toId = data["toId"] as? String ?? ""
 ////        self.topicTitle = data["topicTitle"] as? String ?? ""
-////        self.timestamp = data["timestamp"] as? Timestamp ?? Timestamp(date: Date())
+////        self.timestamp = data["timestamp"] as? Date ?? Date(date: Date())
 ////    }
 //}
 
@@ -53,7 +53,7 @@ struct Topic: Identifiable, Equatable {
     var isCardDeck, isCardBox: Bool
     var isOnCardZone, isOnCardDeck, underDiscussion: Bool
     var height: CGFloat
-    var timestamp: Timestamp
+    var timestamp: Date
     
     var finishTopicViewCondition: [Bool] {
         return [self.isOnCardZone, self.isOnCardDeck, self.underDiscussion ]
@@ -70,7 +70,7 @@ struct Topic: Identifiable, Equatable {
         self.isOnCardDeck = data["isOnCardDeck"] as? Bool ?? true
         self.underDiscussion = data["underDiscussion"] as? Bool ?? false
         self.height = data["height"] as? CGFloat ?? 0
-        self.timestamp = data["timestamp"] as? Timestamp ?? Timestamp()
+        self.timestamp = data["timestamp"] as? Date ?? Date()
     }
 }
 
@@ -86,7 +86,7 @@ extension Topic {
             FirebaseConstants.isOnCardDeck: true,
             FirebaseConstants.underDiscussion: false,
             FirebaseConstants.height: 0,
-            FirebaseConstants.timestamp: Timestamp()
+            FirebaseConstants.timestamp: Date()
         ]),
         Topic(documentId: "커피 먹자", data: [
             FirebaseConstants.uid: "",
@@ -97,7 +97,7 @@ extension Topic {
             FirebaseConstants.isOnCardDeck: true,
             FirebaseConstants.underDiscussion: false,
             FirebaseConstants.height: 0,
-            FirebaseConstants.timestamp: Timestamp()
+            FirebaseConstants.timestamp: Date()
         ]),
         Topic(documentId: "딴데 가자", data: [
             FirebaseConstants.uid: "",
@@ -108,7 +108,7 @@ extension Topic {
             FirebaseConstants.isOnCardDeck: true,
             FirebaseConstants.underDiscussion: false,
             FirebaseConstants.height: 0,
-            FirebaseConstants.timestamp: Timestamp()
+            FirebaseConstants.timestamp: Date()
         ]),
         Topic(documentId: "각자 쉬자", data: [
             FirebaseConstants.uid: "",
@@ -119,7 +119,7 @@ extension Topic {
             FirebaseConstants.isOnCardDeck: true,
             FirebaseConstants.underDiscussion: false,
             FirebaseConstants.height: 0,
-            FirebaseConstants.timestamp: Timestamp()
+            FirebaseConstants.timestamp: Date()
         ]),
         Topic(documentId: "집에 가자", data: [
             FirebaseConstants.uid: "",
@@ -130,7 +130,7 @@ extension Topic {
             FirebaseConstants.isOnCardDeck: true,
             FirebaseConstants.underDiscussion: false,
             FirebaseConstants.height: 0,
-            FirebaseConstants.timestamp: Timestamp()
+            FirebaseConstants.timestamp: Date()
         ])
     ]
 }

--- a/TeamOXY/TeamOXY/Utils/NotificationManager.swift
+++ b/TeamOXY/TeamOXY/Utils/NotificationManager.swift
@@ -1,0 +1,65 @@
+//
+//  NotificationManager.swift
+//  TeamOXY
+//
+//  Created by 최동권 on 2022/06/17.
+//
+
+import SwiftUI
+import UserNotifications
+
+struct NotificationManager {
+    
+    static let shared = NotificationManager()
+    
+    func TimeIntervalNotification(title: String, subtitle: String) {
+        
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.subtitle = subtitle
+        content.sound = .default
+//        content.badge =
+        
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
+        
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: content,
+            trigger: trigger
+        )
+        UNUserNotificationCenter.current().add(request)
+    }
+    
+    func CardzoneNotification(isInCardZoneTime: Date) {
+        // isInCardZoneTime은 파베로부터 받아온 시간
+        let content = UNMutableNotificationContent()
+        content.title = "누군가 쉬고 싶어 합니다!"
+        content.subtitle = "쉼카드를 확인하고 반응해주세요.🥳"
+        content.sound = .default
+        
+        let formatter = DateFormatter()
+        formatter.dateFormat = "mm ss"
+        let time = formatter.string(from: isInCardZoneTime)
+        let timeArr = time.components(separatedBy: " ").map{ (value:String) -> Int in
+            return Int(value) ?? 0
+        }
+        let hour = Calendar.autoupdatingCurrent.component(.hour, from: isInCardZoneTime)
+        
+        var notificationTime = DateComponents()
+        notificationTime.hour = hour
+        notificationTime.minute = timeArr[0]
+        notificationTime.second = timeArr[1] + 1
+        // 어떤 유저가 cardzone에 안건을 던져서 저장된 시간과, 그 안건의 시간정보를 다른 유저사이의 시간 딜레이 때문에 몇초 딜레이 시켜야할 것 같음
+        
+        
+        let trigger = UNCalendarNotificationTrigger(dateMatching: notificationTime, repeats: false)
+        
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: content,
+            trigger: trigger
+        )
+        
+        UNUserNotificationCenter.current().add(request)
+    }
+}

--- a/TeamOXY/TeamOXY/View/BreakTime/BreakTimeView.swift
+++ b/TeamOXY/TeamOXY/View/BreakTime/BreakTimeView.swift
@@ -11,13 +11,14 @@ struct BreakTimeView: View {
     // 설정된 시간
     @State var counter: Int
     @State var countTo: Int
-    
+    @ObservedObject var vm: MeetingRoomViewModel
+    @ObservedObject var viewModel: CarouselViewModel
     // 알람 설정
     @State private var isNotification = true
     
     var body: some View {
         ZStack {
-            CircularTimerView(counter: counter, countTo: countTo)
+            CircularTimerView(counter: counter, countTo: timerViewModel.shared.currentTimer?.timestamp ?? 0, vm: vm, isNotification: $isNotification)
             
             VStack {
                 VStack(alignment: .center) {
@@ -49,10 +50,10 @@ struct BreakTimeView: View {
     }
     
     func displayFinish() -> String{
-        let now = Date()
+        let now = timerViewModel.shared.currentTimer?.setTime
         //TODO: 종료시간 받아와서 출력하기, 알람에 상관없이 고정된 시간을 표현해야함
         //MARK: 알람버튼 누를 때, 종료시간 업데이트되는 것 막아야함
-        let end = now.addingTimeInterval(600)
+        guard let end = now?.addingTimeInterval(Double(timerViewModel.shared.currentTimer?.timestamp ?? 0)) else { return "Date()" }
         let formatter = DateFormatter()
         
         //한국 시간으로 표시
@@ -68,8 +69,8 @@ struct BreakTimeView: View {
     }
 }
 
-struct BreakTimeView_Previews: PreviewProvider {
-    static var previews: some View {
-        BreakTimeView(counter: 1, countTo: 1)
-    }
-}
+//struct BreakTimeView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        BreakTimeView(counter: 1, countTo: 1)
+//    }
+//}

--- a/TeamOXY/TeamOXY/View/BreakTime/CircularTimerView.swift
+++ b/TeamOXY/TeamOXY/View/BreakTime/CircularTimerView.swift
@@ -11,10 +11,12 @@ import SwiftUI
 
 struct CircularTimerView: View {
     @State var counter: Int
-    
-    let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
     var countTo: Int
     
+    @ObservedObject var vm: MeetingRoomViewModel
+    @Binding var isNotification: Bool
+    
+    let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
     var body: some View {
         ZStack {
             CircularProgressBar(counter: counter, countTo: countTo)
@@ -24,6 +26,15 @@ struct CircularTimerView: View {
         .onReceive(timer) { timer in
             if (self.counter < self.countTo) {
                 self.counter += 1
+            }
+            
+            if isNotification && self.countTo - counter == 0 {
+                NotificationManager.shared.TimeIntervalNotification(title: "이쉼전쉼", subtitle: "쉬는시간 끝! 모두 모여주세요.🏃‍♂️")
+                vm.terminateTimer()
+            }
+            
+            if isNotification && self.countTo - counter == 180 {
+                NotificationManager.shared.TimeIntervalNotification(title: "이쉼전쉼", subtitle: "쉬는시간이 3분 남았습니다.⏰")
             }
         }
     }

--- a/TeamOXY/TeamOXY/View/BreakTime/TimeSetView.swift
+++ b/TeamOXY/TeamOXY/View/BreakTime/TimeSetView.swift
@@ -10,9 +10,12 @@ import SwiftUI
 struct TimeSetView: View {
     @ObservedObject var viewModel: CarouselViewModel
     @ObservedObject var vm: MeetingRoomViewModel
+    @State var isActive: Bool = timerViewModel.shared.currentTimer?.isAvailable ?? false
+    
+    // 의문
     
     // time picker data min:5분 ~ max: 30분 59초
-    var minutes = [Int](5...30)
+    var minutes = [Int](0...30)
     var seconds = [Int](0..<60)
     
     //기본 쉬는 시간 : 10분 설정을 위한 인덱스 값
@@ -68,9 +71,14 @@ struct TimeSetView: View {
                 }
                 VStack {
                     Spacer()
-                    NavigationLink(destination: BreakTimeView(counter: 0, countTo: (Int(minutes[minuteSeletion])) * 60 + (Int(seconds[secondSeletion])))) {
-                        RoundButton(buttonType: .primary, title: "쉬는시간 시작", isButton: false, didCompletion: nil)
+                    RoundButton(buttonType: .primary, title: "쉬는시간 시작", isButton: true) {
+                        
+                        vm.updateTimer(countTo: (Int(minutes[minuteSeletion])) * 60 + (Int(seconds[secondSeletion])))
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                            self.isActive.toggle()
+                        }
                     }
+                    NavigationLink("", destination: BreakTimeView(counter: 0, countTo: (Int(minutes[minuteSeletion])) * 60 + (Int(seconds[secondSeletion])), vm: vm, viewModel: viewModel), isActive: $isActive)
                 }
             }
         }

--- a/TeamOXY/TeamOXY/View/MeetingRoom/CarouselView.swift
+++ b/TeamOXY/TeamOXY/View/MeetingRoom/CarouselView.swift
@@ -20,7 +20,8 @@ struct CarouselView: View {
     
     @State var viewState = CGSize(width: 0, height: 0) // 가운데 카드 중앙부의 위치
     @State var degree = 0.0
-    
+    // isincardzone일 때 notification을 한 번만 보내기 위함
+    @State var isNotification: Bool = true
     var spacerWidth: CGFloat = UIScreen.screenWidth * 0.243
     
     private func onHorizontalDragEnded(drag: DragGesture.Value) {
@@ -125,8 +126,8 @@ struct CarouselView: View {
                             viewModel.FinishTopicViewCondition = [true, false, true]
                             viewModel.isCardBox = false
                             viewState.height = viewModel.height
+                            viewModel.notificateTopicToUser()
                         }
-                    
                 }
                 
                 ForEach(viewModel.topicViews, id: \.id){ topic in
@@ -167,14 +168,16 @@ struct CarouselView: View {
                                 // 카드 놓는 공간 안에 있다면
                                 if viewState.height < CarouselViewConstants.secondCardLocation {
                                     print("inside zone")
+                                    self.viewModel.notificateTopicToMe()
+                                    self.viewModel.ownNotification = false
                                     viewModel.FinishTopicViewCondition = [true, false, true]
                                     viewModel.isCardBox = false
                                     viewModel.height = self.viewState.height
                                     
                                     // 카드 놓는 곳으로 위치시키기
                                     viewState.height = -UIScreen.screenHeight * 0.23// 원래-370
-                                    
                                     self.viewModel.storeTopicInformation()
+                                    
                                     // 논의중이고 카드존에 없다면
                                 } else if viewModel.FinishTopicViewCondition[2] == true {
                                     // 카드존에 없고, 논의중이 아닐 때, finishTopicView를 띄우고
@@ -185,7 +188,9 @@ struct CarouselView: View {
                                     
                                     // 다시 덱으로 위치시키기
                                     self.viewState.height = CarouselViewConstants.initialCardLocation
+                                    
                                     self.viewModel.storeTopicInformation()
+                                    
                                 } else {
                                     // 카드존에 없고, 논의중이 아닐 때 제자리로 돌려보냄
                                     print("not inside zone sfdsfsf")

--- a/TeamOXY/TeamOXY/View/MeetingRoom/FinishTopicView.swift
+++ b/TeamOXY/TeamOXY/View/MeetingRoom/FinishTopicView.swift
@@ -26,7 +26,8 @@ struct FinishTopicView: View {
                     Button(action: {
                         // FinishTopicView뜨는 조건 초기화
                         viewModel.FinishTopicViewCondition = [false, true, false]
-                        
+                        // isinCardZone에서 드래그를 연속으로 놓는 경우 방지
+                        self.viewModel.ownNotification = true
                         // 로티 on/off
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                             viewModel.isCompletion = true

--- a/TeamOXY/TeamOXY/View/MeetingRoom/MeetingRoomView.swift
+++ b/TeamOXY/TeamOXY/View/MeetingRoom/MeetingRoomView.swift
@@ -17,10 +17,26 @@ struct MeetingRoomView: View {
     
     @Binding var backToHome: Bool
     
+    @State var isActive: Bool = (timerViewModel.shared.currentTimer?.isAvailable ?? false)
+    
     var scannedCodeUrl: String?
     
     var body: some View {
-            VStack {
+        VStack {
+            if vm.isTimerAvailable {
+                BreakTimeView(counter: 0, countTo: 100, vm: vm, viewModel: viewModel)
+                    .onAppear{
+                        // 설정한 사람이 아닌 다른 사람의 폰에서도 미팅룸 초기화면으로 돌아가게하기위함
+                        viewModel.FinishTopicViewCondition = [false, true, false]
+                        viewModel.isCardBox = true
+                        viewModel.isCardDeck = true
+                        self.viewModel.topicTitle = ""
+                        self.viewModel.storeTopicInformation()
+                        
+                        self.viewModel.ownNotification = true
+                    }
+            }
+            else {
                 ZStack{
                     if viewModel.FinishTopicViewCondition != [false, true, true] && viewModel.isCardBox {
                         RoundedRectangle(cornerRadius: 5)
@@ -41,9 +57,9 @@ struct MeetingRoomView: View {
                             .offset(y: -UIScreen.screenHeight * 0.11)
                             .transition(AnyTransition.opacity.animation(.easeInOut))
                     }
-                  
+                    
                     CarouselView(viewModel: viewModel, vm: vm, emojiViewModel: emojiViewModel)
-
+                }
             }
         }
         .navigationTitle("\(vm.roomId) \(vm.users.count < 2 ? 1 : vm.users.count)")

--- a/TeamOXY/TeamOXY/ViewModel/CarouselViewModel.swift
+++ b/TeamOXY/TeamOXY/ViewModel/CarouselViewModel.swift
@@ -21,8 +21,10 @@ class CarouselViewModel: ObservableObject {
     @Published var currentCardIndex = 0
     @Published var currentTopic: Topic?
     @Published var topicViews: [Topic] = Topic.topicViews
+    @Published var currentTime: Date?
     
-    
+    @Published var ownNotification: Bool = true
+    @Published var userNotification: Bool = true
     func storeTopicInformation() {
         guard let roomId = FirebaseManager.shared.roomId else {
             print("없어!!!!")
@@ -45,6 +47,13 @@ class CarouselViewModel: ObservableObject {
             FirebaseConstants.height: self.height,
             FirebaseConstants.timestamp: Date()
         ] as [String : Any]
+        
+//        self.currentTime = topicData[FirebaseConstants.timestamp] as? Date
+//
+//        if self.isNotification {
+//            NotificationManager.shared.CardzoneNotification(isInCardZoneTime: self.currentTime ?? Date())
+//        }
+//        self.isNotification = false
         
         FirebaseManager.shared.firestore
             .collection(FirebaseConstants.rooms)
@@ -100,12 +109,26 @@ class CarouselViewModel: ObservableObject {
                 self.FinishTopicViewCondition = finishTopicViewCondition
                 self.isCardBox = currentTopic.isCardBox
                 
+                
 //
 //                self.height = CGFloat(currentTopic.height)
 //                self.width = CGFloat(currentTopic.width)
                 
                 
             }
+    }
+   
+    func notificateTopicToUser() {
+        if self.userNotification {
+            NotificationManager.shared.CardzoneNotification(isInCardZoneTime: Date())
+        }
+    }
+    
+    func notificateTopicToMe() {
+        if self.ownNotification {
+            print("실행됐음")
+            NotificationManager.shared.CardzoneNotification(isInCardZoneTime: Date())
+        }
     }
 
 }

--- a/TeamOXY/TeamOXY/ViewModel/MeetingRoomViewModel.swift
+++ b/TeamOXY/TeamOXY/ViewModel/MeetingRoomViewModel.swift
@@ -19,6 +19,9 @@ class MeetingRoomViewModel: ObservableObject {
     
     @Published var isLogin = false
     
+    @Published var currentTimer: TimeModel?
+    @Published var isTimerAvailable = false
+    
     func anonymousLogin(scannedCodeUrl: String?, nickname: String) {
         FirebaseManager.shared.auth.signInAnonymously { result, error in
             if let error = error {
@@ -34,16 +37,9 @@ class MeetingRoomViewModel: ObservableObject {
     
     func storeUserInformation(scannedCodeUrl: String?, nickname: String) {
         guard let uid = FirebaseManager.shared.auth.currentUser?.uid else { return }
-        
-        Messaging.messaging().token { token, error in
-            if let error = error {
-                print("Error fetching FCM registration token: \(error)")
-                return
-            }
-            guard let token = token else { return }
-            print("FCM registration token: \(token)")
-            self.fcmToken = token
             
+        self.fcmToken = TokenModel.shared.token ?? ""
+        
             let userData = [
                 FirebaseConstants.uid: uid,
                 FirebaseConstants.nickname: nickname,
@@ -65,6 +61,7 @@ class MeetingRoomViewModel: ObservableObject {
                         }
                         
                         print("Succeessfully stored user information")
+                        self.fetchTimer(roomId: scannedCodeUrl)
                     }
             } else {
                 FirebaseManager.shared.firestore
@@ -79,11 +76,10 @@ class MeetingRoomViewModel: ObservableObject {
                         }
                         
                         print("Succeessfully stored user information")
+                        self.storeTimer()
                     }
             }
-            
             self.fetchCurrentUser(self.roomId)
-        }
     }
     
     func fetchCurrentUser(_ title: String) {
@@ -154,4 +150,154 @@ class MeetingRoomViewModel: ObservableObject {
                 })
             }
     }
+    
+    func storeTimer() {
+           
+           let timerData = [
+               "timestamp": 0,
+               "setTime": Date(),
+               "isAvailable": false
+           ] as [String : Any]
+           
+           FirebaseManager.shared.firestore
+               .collection(FirebaseConstants.rooms)
+               .document(self.roomId)
+               .collection(FirebaseConstants.timers)
+               .document("timer")
+               .setData(timerData) { error in
+                   if let error = error {
+                       print("Failed to store timer information: \(error)")
+                       return
+                   }
+                   
+                   print("Succeessfully stored timer information")
+                   
+                   self.fetchTimer(roomId: self.roomId)
+               }
+       }
+       
+       // 타이머 컬렉션 생성 및 초기화
+       func fetchTimer(roomId: String?) {
+
+           FirebaseManager.shared.firestore
+               .collection(FirebaseConstants.rooms)
+               .document(self.roomId)
+               .collection(FirebaseConstants.timers)
+               .addSnapshotListener { querySnapshot, error in
+                   if let error = error {
+                       print("Failed to listen for new timer: \(error)")
+                       return
+                   }
+                   
+                   print("변경 감지")
+                   
+                   // 변경 감지 시 실행될 부분
+                   let change = querySnapshot?.documentChanges[0]
+                   print("타이머 변경 감지!")
+
+   //                self.currentUser = try? snapshot?.data(as: User.self)
+   //                FirebaseManager.shared.currentUser = self.currentUser
+                   
+                   let rm = try? change?.document.data(as: TimeModel.self)
+                   timerViewModel.shared.currentTimer = rm
+                   self.isTimerAvailable = timerViewModel.shared.currentTimer?.isAvailable ?? false
+                   
+                   print("타이머 뷰모델을 쉐어드에 저장\(timerViewModel.shared.currentTimer?.isAvailable)")
+   //                    self.currentTimer = rm
+   //                    print("rm: \(rm.timestamp)")
+   //                    self.isTimerAvailable = rm.isAvailable
+                   
+                   
+                   // 타이머 설정
+                   // 끝
+               }
+       }
+       
+       // 타이머 설정(업데이트)
+       func updateTimer(countTo: Int) {
+           print("roomId in updateTimetr: \(self.roomId)")
+
+           print("updateTimer!!!!!!!!!!")
+           print("countTo: \(countTo)")
+           print("!!!!!!!!!!")
+           
+           
+   //
+   //        let timerUpdate = FirebaseManager.shared.firestore
+   //                .collection(FirebaseConstants.rooms)
+   //                .document(self.roomId)
+   //                .collection(FirebaseConstants.timers)
+   //                .document("timer")
+           
+           let timerData = [
+               "timestamp": countTo,
+               "setTime": Date(),
+               // false -> true
+               "isAvailable": true
+           ] as [String : Any]
+           
+           FirebaseManager.shared.firestore
+               .collection(FirebaseConstants.rooms)
+               .document(self.roomId)
+               .collection(FirebaseConstants.timers)
+               .document("timer")
+               .setData(timerData) { error in
+                   if let error = error {
+                       print("Failed to store timer information: \(error)")
+                       return
+                   }
+                   
+                   print("Succeessfully set timer information")
+                   
+   //                self.fetchTimer(roomId: self.roomId)
+               }
+   //
+   //        timerUpdate.updateData([
+   //            FirebaseConstants.timestamp : countTo,
+   //            FirebaseConstants.setTime : Date(),
+   //            FirebaseConstants.isAvailable : false
+   //        ])
+           
+       }
+       
+       func terminateTimer() {
+      print("타이머 종료시키기")
+           
+   //
+   //        let timerUpdate = FirebaseManager.shared.firestore
+   //                .collection(FirebaseConstants.rooms)
+   //                .document(self.roomId)
+   //                .collection(FirebaseConstants.timers)
+   //                .document("timer")
+           
+           let timerData = [
+               "timestamp": 10,
+               "setTime": Date(),
+               // false -> true
+               "isAvailable": false
+           ] as [String : Any]
+           
+           FirebaseManager.shared.firestore
+               .collection(FirebaseConstants.rooms)
+               .document(self.roomId)
+               .collection(FirebaseConstants.timers)
+               .document("timer")
+               .setData(timerData) { error in
+                   if let error = error {
+                       print("Failed to store timer information: \(error)")
+                       return
+                   }
+                   
+                   print("Succeessfully set timer information")
+                   
+   //                self.fetchTimer(roomId: self.roomId)
+               }
+   //
+   //        timerUpdate.updateData([
+   //            FirebaseConstants.timestamp : countTo,
+   //            FirebaseConstants.setTime : Date(),
+   //            FirebaseConstants.isAvailable : false
+   //        ])
+           
+       }
 }

--- a/TeamOXY/TeamOXY/ViewModel/TimerViewModel.swift
+++ b/TeamOXY/TeamOXY/ViewModel/TimerViewModel.swift
@@ -1,0 +1,13 @@
+//
+//  TimerViewModel.swift
+//  TeamOXY
+//
+//  Created by 최동권 on 2022/06/19.
+//
+
+import Foundation
+
+class timerViewModel: NSObject {
+    var currentTimer: TimeModel?
+    static let shared = timerViewModel()
+}


### PR DESCRIPTION
## 작업 내용
- 깃이 꼬여버리는 바람에 develop 에서 다시 브랜치파서 작성했던 코드 복붙했습니다.
- topic에 푸시노티피케이션 추가
- timer에 푸시노티피케이션 추가
- firebase에 저장된 date값을 이용하여, topic information을 저장하고 fetch하는 함수에 넣으려고 했으나, stored, fetch함수가
너무 빈번하게 일어나서 포기하고 조건이 충족되는 Date()로 바로 보내게 구현하였습니다.
## 리뷰 포인트
- 다른 유저가 topic을 올렸을 때 다른 사람의 폰에서도 알림이 잘 오는지, 
- topic을 올린 사람의 폰에서도 알림이 잘 오는지,
- timer뷰에서 3분전, 0분에 알림이 잘 가는지
- 현재 테스트를 위해서 picker의 minute범위를 0분부터 시작하게 해놨습니다. 테스트 다 해보시고 5분으로 바꿔야할 수 있습니다!
- 다른 휴대폰에서 토픽이 연결되려면 서로 한 번씩은 던지고 나서 연결되는 것 같습니다. notification도 연결된 조건을 가져오기 때문에 
서로 연결이 되고 나서야 두 휴대폰에 모두 정상적으로 알림이 가는 것 같습니다
## 다음으로 진행될 작업

## 질문

## References
